### PR TITLE
Add core trading bot modules, CLI, and tests

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from locationalfreedombot.bot import TradingBot
+
+CONFIG_PATH = Path("config/config.yaml")
+
+
+def load_config(path: Path = CONFIG_PATH):
+    with open(path) as f:
+        return json.load(f)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="LocationalFreedomBot controller")
+    parser.add_argument("command", choices=["start", "stop", "status"])
+    args = parser.parse_args()
+
+    config = load_config()
+    bot = TradingBot(config)
+
+    if args.command == "start":
+        bot.start()
+    elif args.command == "stop":
+        bot.stop()
+    elif args.command == "status":
+        print(bot.status())
+
+
+if __name__ == "__main__":
+    main()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,7 @@
+{
+  "wallet": {"balance": 1000},
+  "strategy": {"rsi_period": 14, "overbought": 70, "oversold": 30},
+  "token": {"symbol": "TEST", "liquidity": 100000},
+  "trade": {"amount": 100, "price_history": [50,49,48,47,46,45,44,43,42,41,40,39,38,37,36]},
+  "rugpull": {"min_liquidity": 50000}
+}

--- a/locationalfreedombot/__init__.py
+++ b/locationalfreedombot/__init__.py
@@ -1,0 +1,3 @@
+"""LocationalFreedomBot package."""
+
+from .bot import TradingBot  # noqa: F401

--- a/locationalfreedombot/bot.py
+++ b/locationalfreedombot/bot.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Dict
+
+from .wallet import Wallet
+from .strategy import RSIStrategy
+from .rugpull import RugPullChecker
+from .execution import TradeExecutor
+
+
+class TradingBot:
+    """High level trading bot orchestrating modules."""
+
+    def __init__(self, config: Dict) -> None:
+        self.config = config
+        wallet_cfg = config.get("wallet", {})
+        strategy_cfg = config.get("strategy", {})
+        rug_cfg = config.get("rugpull", {})
+        self.wallet = Wallet(wallet_cfg.get("balance", 0.0))
+        self.strategy = RSIStrategy(
+            period=strategy_cfg.get("rsi_period", 14),
+            overbought=strategy_cfg.get("overbought", 70),
+            oversold=strategy_cfg.get("oversold", 30),
+        )
+        self.checker = RugPullChecker(rug_cfg.get("min_liquidity", 0.0))
+        self.executor = TradeExecutor(self.wallet, self.checker)
+        self.running = False
+        self.logger = logging.getLogger(__name__)
+
+    def start(self) -> None:
+        self.running = True
+        trade_cfg = self.config.get("trade", {})
+        token_cfg = self.config.get("token", {})
+        prices = trade_cfg.get("price_history", [])
+        amount = trade_cfg.get("amount", 0.0)
+        signal = self.strategy.generate_signal(prices)
+        self.logger.info("Strategy signal: %s", signal)
+        self.executor.execute(signal, token_cfg, amount)
+
+    def stop(self) -> None:
+        self.running = False
+        self.logger.info("Bot stopped")
+
+    def status(self) -> str:
+        return "running" if self.running else "stopped"

--- a/locationalfreedombot/execution.py
+++ b/locationalfreedombot/execution.py
@@ -1,0 +1,29 @@
+import logging
+from typing import Dict
+
+from .wallet import Wallet
+from .rugpull import RugPullChecker
+
+
+class TradeExecutor:
+    """Executes trades if they pass rug pull checks and funds are available."""
+
+    def __init__(self, wallet: Wallet, checker: RugPullChecker) -> None:
+        self.wallet = wallet
+        self.checker = checker
+        self.logger = logging.getLogger(__name__)
+
+    def execute(self, signal: str, token: Dict, amount: float) -> bool:
+        if signal != "buy":
+            self.logger.info("No trade executed for signal %s", signal)
+            return False
+        if not self.checker.is_safe(token):
+            self.logger.warning("Trade blocked for token %s", token.get("symbol"))
+            return False
+        try:
+            self.wallet.withdraw(amount)
+        except ValueError:
+            self.logger.error("Insufficient funds for trade")
+            return False
+        self.logger.info("Executed trade for token %s amount %s", token.get("symbol"), amount)
+        return True

--- a/locationalfreedombot/rugpull.py
+++ b/locationalfreedombot/rugpull.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Dict
+
+
+class RugPullChecker:
+    """Checks token metadata for simple rug pull indicators."""
+
+    def __init__(self, min_liquidity: float = 0.0) -> None:
+        self.min_liquidity = min_liquidity
+        self.logger = logging.getLogger(__name__)
+
+    def is_safe(self, token: Dict) -> bool:
+        liquidity = token.get("liquidity", 0.0)
+        safe = liquidity >= self.min_liquidity
+        if not safe:
+            self.logger.warning(
+                "Token %s failed rug pull check: liquidity %s below %s",
+                token.get("symbol"),
+                liquidity,
+                self.min_liquidity,
+            )
+        return safe

--- a/locationalfreedombot/strategy.py
+++ b/locationalfreedombot/strategy.py
@@ -1,0 +1,41 @@
+import logging
+from typing import List
+
+
+class RSIStrategy:
+    """Very small RSI based trading strategy."""
+
+    def __init__(self, period: int = 14, overbought: float = 70, oversold: float = 30) -> None:
+        self.period = period
+        self.overbought = overbought
+        self.oversold = oversold
+        self.logger = logging.getLogger(__name__)
+
+    def compute_rsi(self, prices: List[float]) -> float:
+        if len(prices) <= self.period:
+            raise ValueError("Not enough price data to compute RSI")
+        gains = 0.0
+        losses = 0.0
+        # Use the last `period` differences
+        for i in range(len(prices) - self.period, len(prices)):
+            delta = prices[i] - prices[i - 1]
+            if delta > 0:
+                gains += delta
+            else:
+                losses -= delta
+        avg_gain = gains / self.period
+        avg_loss = losses / self.period
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        rsi = 100 - (100 / (1 + rs))
+        self.logger.debug("RSI value computed: %s", rsi)
+        return rsi
+
+    def generate_signal(self, prices: List[float]) -> str:
+        rsi = self.compute_rsi(prices)
+        if rsi < self.oversold:
+            return "buy"
+        if rsi > self.overbought:
+            return "sell"
+        return "hold"

--- a/locationalfreedombot/wallet.py
+++ b/locationalfreedombot/wallet.py
@@ -1,0 +1,22 @@
+import logging
+
+
+class Wallet:
+    """Simple wallet to manage balances."""
+
+    def __init__(self, balance: float = 0.0) -> None:
+        self.balance = float(balance)
+        self.logger = logging.getLogger(__name__)
+
+    def deposit(self, amount: float) -> None:
+        self.balance += amount
+        self.logger.info("Deposited %s", amount)
+
+    def withdraw(self, amount: float) -> None:
+        if amount > self.balance:
+            raise ValueError("Insufficient funds")
+        self.balance -= amount
+        self.logger.info("Withdrew %s", amount)
+
+    def get_balance(self) -> float:
+        return self.balance

--- a/tests/test_rugpull_checks.py
+++ b/tests/test_rugpull_checks.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from locationalfreedombot.rugpull import RugPullChecker
+
+
+def test_rugpull_checker_flags_low_liquidity():
+    checker = RugPullChecker(min_liquidity=1000)
+    assert not checker.is_safe({"symbol": "BAD", "liquidity": 10})
+    assert checker.is_safe({"symbol": "GOOD", "liquidity": 5000})

--- a/tests/test_trading_flow.py
+++ b/tests/test_trading_flow.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from locationalfreedombot.wallet import Wallet
+from locationalfreedombot.strategy import RSIStrategy
+from locationalfreedombot.rugpull import RugPullChecker
+from locationalfreedombot.execution import TradeExecutor
+
+
+CONFIG_PATH = Path("config/config.yaml")
+
+
+def load_config():
+    with open(CONFIG_PATH) as f:
+        return json.load(f)
+
+
+def test_trade_executes_when_safe():
+    cfg = load_config()
+    wallet = Wallet(cfg["wallet"]["balance"])
+    strategy = RSIStrategy(
+        cfg["strategy"]["rsi_period"],
+        cfg["strategy"]["overbought"],
+        cfg["strategy"]["oversold"],
+    )
+    checker = RugPullChecker(cfg["rugpull"]["min_liquidity"])
+    executor = TradeExecutor(wallet, checker)
+
+    prices = cfg["trade"]["price_history"]
+    signal = strategy.generate_signal(prices)
+    token = cfg["token"]
+    amount = cfg["trade"]["amount"]
+
+    assert executor.execute(signal, token, amount)
+    assert wallet.get_balance() == cfg["wallet"]["balance"] - amount
+
+
+def test_trade_blocked_on_rugpull():
+    wallet = Wallet(1000)
+    checker = RugPullChecker(min_liquidity=50000)
+    executor = TradeExecutor(wallet, checker)
+
+    token = {"symbol": "SCAM", "liquidity": 10}
+    signal = "buy"
+    amount = 100
+
+    assert not executor.execute(signal, token, amount)
+    assert wallet.get_balance() == 1000


### PR DESCRIPTION
## Summary
- Implement wallet management, RSI strategy, rug-pull safety checks, and trade execution modules.
- Expose start/stop/status commands in `cli.py` using configuration from `config/config.yaml`.
- Add test suite covering trading flow and rug-pull detection.

## Testing
- `pytest -q`
- `python cli.py status`
- `python cli.py start`
- `python cli.py stop`

------
https://chatgpt.com/codex/tasks/task_e_68b7d77a62c8832186dc8610f7480327